### PR TITLE
Fix file installation paths to better conform to conventions

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ contents:
   dst: /usr/bin/{{ .App }}
 {{if eq .Binary "minio" }}
 - src: {{ .SystemdUnit }}
-  dst: /etc/systemd/system/minio.service
+  dst: /lib/systemd/system/minio.service
 {{end}}
 `
 


### PR DESCRIPTION
* Install `minio.service` into /`lib/`

  `/etc` is intended for configuration files created or edited by the user.

  Systemd units installed by package manager should go to `/lib`.

  Changes, if necessary, are easily achieved with "drop-in" files.

* Install binaries to `/usr/bin`, not `/usr/local/bin`

  `/usr/local` is intended for programs installed manually by the user.

  Files installed by package manager should go to `/usr` directly,
  even if they come from third-party source.