### PR TITLE
Create minio-user when installing package

### DIFF
--- a/main.go
+++ b/main.go
@@ -357,6 +357,25 @@ func doPackage(appName, release, packager string) error {
 		}
 
 		for _, pkger := range strings.Split(packager, ",") {
+			switch pkger {
+			case "deb":
+				config.Depends = []string{"adduser"}
+				config.Scripts.PreInstall = ""
+				config.Scripts.PostInstall = "./scripts/deb_postinst"
+			case "rpm":
+				config.Depends = []string{"shadow-utils"}
+				config.Scripts.PreInstall = "./scripts/rpm_preinstall"
+				config.Scripts.PostInstall = ""
+			case "apk":
+				config.Depends = []string{}
+				config.Scripts.PreInstall = "./scripts/apk_preinstall"
+				config.Scripts.PostInstall = ""
+			default:
+				config.Depends = []string{}
+				config.Scripts.PreInstall = ""
+				config.Scripts.PostInstall = ""
+			}
+
 			info, err := config.Get(pkger)
 			if err != nil {
 				return err

--- a/scripts/apk_preinstall
+++ b/scripts/apk_preinstall
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+addgroup -S minio-user 2>/dev/null
+adduser -S -D -H -h /dev/null -s /sbin/nologin -G minio-user -g minio-user minio-user 2>/dev/null
+
+exit 0

--- a/scripts/deb_postinst
+++ b/scripts/deb_postinst
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = configure ]; then
+    adduser --system \
+            --quiet \
+            --home /nonexistent \
+            --no-create-home \
+            --group \
+            minio-user
+fi

--- a/scripts/rpm_preinstall
+++ b/scripts/rpm_preinstall
@@ -1,0 +1,4 @@
+getent group minio-user >/dev/null || groupadd -r minio-user
+getent passwd minio-user >/dev/null || \
+    useradd -r -g minio-user -d / -s /sbin/nologin minio-user
+exit 0


### PR DESCRIPTION
This is common practice for packages. All distributions I've ever seen automatically create users for services, where appropriate. This removes annoying manual step that basically never changes.

For `.deb`, I scraped live system for examples using the following command:

    grep -RE '(adduser|useradd)' /var/lib/dpkg/info/

Users are created in the configure stage of postinst, and typically not removed on uninstall (to prevent problems with uid reuse).

For `.rpm`, I followed the official Fedora packaging guidelines[1].

For `.apk`, I again scraped Alpine package repository, and followed an example[2].

I've tested the package in all corresponding distributions (Debian, Ubuntu, Fedora, Alpine), and ensured that the user is actually created.

[1] https://fedoraproject.org/wiki/Packaging:UsersAndGroups
[2] https://git.alpinelinux.org/aports/