### PR TITLE
Add EDGE release support and Kubernetes/Docker docs for sidekick/warp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,184 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+pkger is a packaging tool for MinIO projects that generates DEB, RPM, and APK packages along with installation metadata JSON files. It's built in Go as a single-file application (`main.go`) that uses the nfpm library for package generation.
+
+## Building and Running
+
+Build the project:
+```bash
+go build -o pkger main.go
+```
+
+The binary is self-contained and uses command-line flags for all configuration.
+
+## Core Architecture
+
+### Single-file Design
+The entire application is in `main.go` (~1000 lines). Key components:
+- **Command-line parsing**: Uses `kingpin` for flag handling
+- **Package generation**: Uses `goreleaser/nfpm/v2` library with support for deb, rpm, and apk formats
+- **Template system**: Uses Go's `text/template` for generating nfpm config (lines 88-119)
+- **JSON generation**: Creates download metadata files for different applications and platforms
+
+### Application Types
+pkger supports multiple MinIO applications, each with different versioning and architecture requirements:
+
+1. **minio/mc**: Date-based releases (e.g., `RELEASE.2025-03-12T00-00-00Z`)
+   - Supports: amd64, arm64, ppc64le
+   - Generates packages and cross-platform download metadata
+
+2. **minio-enterprise/mc-enterprise**: Enterprise variants (date-based)
+   - Supports: amd64, arm64 only
+   - Generates AIStor-branded download URLs
+
+3. **sidekick**: Load balancer (date-based releases)
+   - Supports: amd64, arm64 only
+   - Generates package-only metadata (no binary downloads)
+
+4. **warp**: Benchmarking tool (semantic versioning, e.g., `v0.4.3`)
+   - Supports: amd64, arm64 only
+   - Strips 'v' prefix from package filenames
+   - Cross-platform: Linux, macOS (arm64), Windows (amd64)
+
+### Version Handling
+- **Date-based** (`RELEASE.2025-03-12T00-00-00Z`): Converted to semver format `20250312000000.0.0` via `semVerRelease()` (lines 793-806)
+- **Semantic** (`v0.4.3` for warp): Validated and 'v' prefix stripped (lines 731-744)
+
+### Package Generation Flow
+1. Parse release tag and convert to appropriate version format
+2. For each architecture (filtered by app requirements):
+   - Generate nfpm config from template (lines 865-920)
+   - Create packages in `{appName}-release/linux-{arch}/` directory
+   - Generate SHA256 checksums for each package
+   - Create symlinks for latest package
+3. Generate `downloads-{appName}.json` metadata file
+
+## Common Commands
+
+Run pkger for minio (date-based release):
+```bash
+# Requires: minio.service file and binaries in dist/linux-{arch}/
+pkger -r RELEASE.2025-03-12T00-00-00Z --appName minio --releaseDir=dist
+```
+
+Run pkger for sidekick:
+```bash
+# Requires: binaries in sidekick-release/linux-{arch}/
+pkger -r RELEASE.2025-03-12T00-00-00Z --appName sidekick
+```
+
+Run pkger for warp (semantic versioning):
+```bash
+# Requires: binaries in warp-release/linux-{arch}/
+pkger -r v0.4.3 --appName warp
+```
+
+Build specific package formats only:
+```bash
+pkger -r <release> --appName <app> --packager deb,rpm
+```
+
+Ignore missing architectures (continue on errors):
+```bash
+pkger -r <release> --appName <app> --ignore
+```
+
+Skip package building (only generate JSON):
+```bash
+pkger -r <release> --appName <app> --no-pkg
+```
+
+Generate EDGE release (uses /edge/ path instead of /release/):
+```bash
+pkger -r RELEASE.2025-03-12T00-00-00Z --appName minio-enterprise --edge --no-pkg
+```
+
+## Key Flags
+
+- `-r, --release`: Release tag (required). Format depends on app type
+- `-a, --appName`: Application name (default: "minio")
+- `-d, --releaseDir`: Directory containing binaries (default: "{appName}-release")
+- `-p, --packager`: Package formats to build (default: "deb,rpm,apk")
+- `-i, --ignore`: Ignore missing architecture errors
+- `-n, --no-pkg`: Skip package generation
+- `-e, --edge`: Generate EDGE release URLs (uses /edge/ path)
+- `-s, --scriptsDir`: Directory with package scripts (preinstall.sh, postinstall.sh, etc.)
+- `-l, --license`: Package license (default: "AGPLv3")
+- `--deps`: JSON file with package dependencies
+
+## Important Implementation Details
+
+### Architecture Mapping
+- RPM uses x86_64/aarch64 (see `rpmArchMap`, lines 150-153)
+- DEB uses amd64/arm64 (see `debArchMap`, lines 155-158)
+
+### Download URL Patterns
+The JSON generators create download metadata with different URL structures:
+- **Community**: `dl.min.io/{server|client}/{appName}/release/...`
+- **Enterprise Release**: `dl.min.io/aistor/{appName}/release/...`
+- **Enterprise EDGE**: `dl.min.io/aistor/{appName}/edge/...` (with `--edge` flag)
+- **Sidekick/Warp**: Always use `dl.min.io/aistor/` path
+
+### EDGE Release Support
+- Use `--edge` flag to generate EDGE release metadata
+- Changes URL path from `/release/` to `/edge/`
+- Generates separate JSON file: `downloads-{appName}-edge.json`
+- Docker/Podman instructions use release tag (not `:latest`)
+- Package building (RPM/DEB) works the same for both release and EDGE
+
+### Special Cases
+- **minio/aistor**: Includes `minio.service` systemd file in packages (lines 103-106)
+- **mc packages**: Binary named "mc" but package name is "mcli" (lines 870-872)
+- **warp**: Version validation enforces `vX.Y.Z` format (lines 734-742)
+- **Docker tags**: All Docker/Podman instructions now use actual release tags instead of `:latest`
+
+## Testing Changes
+
+When modifying version handling or JSON generation:
+1. Test with all app types: minio, sidekick, warp, minio-enterprise
+2. Verify package filenames match conventions (no 'v' prefix for warp)
+3. Check generated JSON URLs point to correct dl.min.io paths
+4. Ensure architecture filtering works correctly for each app
+
+## File Structure
+
+```
+pkger/
+├── main.go              # Single-file application
+├── go.mod               # Go 1.25+ required
+├── minio.service        # Systemd service file (included in minio packages)
+├── dist/                # GoReleaser output for pkger itself
+└── {app}-release/       # Input/output directories for packaging
+    └── linux-{arch}/
+        ├── {binary}.{release}        # Input binary
+        ├── {package}.rpm             # Output package
+        ├── {package}.deb
+        ├── {package}.apk
+        └── *.sha256sum               # Checksums
+```
+
+## Testing
+
+Run unit tests:
+```bash
+go test -v
+```
+
+The test suite (`main_test.go`) covers:
+- Version conversion (date-based and semantic)
+- JSON generation for all app types
+- EDGE release URL validation
+- Docker tag usage verification
+- Architecture mapping correctness
+- URL path structure validation
+
+## Development Notes
+
+- Comprehensive unit tests exist in `main_test.go` covering all JSON generation functions
+- Package scripts (preinstall.sh, etc.) are optional and loaded from `--scriptsDir`
+- The template system expects specific directory structures; paths are not validated upfront
+- JSON generation happens regardless of package build success/failure

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,407 @@
+/*
+ * Copyright (C) 2020-2025, MinIO, Inc.
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSemVerRelease tests the conversion from release tags to semver format
+func TestSemVerRelease(t *testing.T) {
+	tests := []struct {
+		name        string
+		releaseTag  string
+		expected    string
+		expectPanic bool
+	}{
+		{
+			name:       "Standard release tag",
+			releaseTag: "RELEASE.2025-03-12T00-00-00Z",
+			expected:   "20250312000000.0.0",
+		},
+		{
+			name:       "Release with hotfix",
+			releaseTag: "RELEASE.2025-03-12T00-00-00Z.hotfix.1",
+			expected:   "20250312000000.0.0.hotfix.1",
+		},
+		{
+			name:        "Invalid format - no RELEASE prefix",
+			releaseTag:  "2025-03-12T00-00-00Z",
+			expectPanic: true,
+		},
+		{
+			name:        "Invalid format - too few fields",
+			releaseTag:  "RELEASE",
+			expectPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected panic but got none")
+					}
+				}()
+			}
+
+			result := semVerRelease(tt.releaseTag)
+			if !tt.expectPanic && result != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestGenerateEnterpriseDownloadsJSON tests enterprise JSON generation
+func TestGenerateEnterpriseDownloadsJSON(t *testing.T) {
+	semVerTag := "20250312000000.0.0"
+	releaseTag := "RELEASE.2025-03-12T00-00-00Z"
+
+	t.Run("MinIO Enterprise Release", func(t *testing.T) {
+		result := generateEnterpriseDownloadsJSON(semVerTag, "minio-enterprise", releaseTag, false)
+
+		// Verify structure
+		if result.Subscriptions == nil {
+			t.Fatal("Subscriptions is nil")
+		}
+		if _, ok := result.Subscriptions["Enterprise"]; !ok {
+			t.Fatal("Enterprise subscription not found")
+		}
+
+		// Verify Linux AIStor Server has required fields
+		linuxData := result.Subscriptions["Enterprise"].Linux["AIStor Server"]["amd64"]
+		if linuxData.Bin == nil {
+			t.Error("Binary download info missing")
+		}
+		if linuxData.RPM == nil {
+			t.Error("RPM download info missing")
+		}
+		if linuxData.Deb == nil {
+			t.Error("DEB download info missing")
+		}
+
+		// Verify release path
+		if linuxData.Bin.Download != "" && !strings.Contains(linuxData.Bin.Download, "/release/") {
+			t.Error("Binary download should contain '/release/' path")
+		}
+	})
+
+	t.Run("MinIO Enterprise EDGE", func(t *testing.T) {
+		result := generateEnterpriseDownloadsJSON(semVerTag, "minio-enterprise", releaseTag, true)
+
+		// Verify EDGE path
+		linuxData := result.Subscriptions["Enterprise"].Linux["AIStor Server"]["amd64"]
+		if !strings.Contains(linuxData.Bin.Download, "/edge/") {
+			t.Error("EDGE release should contain '/edge/' path")
+		}
+		if !strings.Contains(linuxData.RPM.Download, "/edge/") {
+			t.Error("EDGE RPM should contain '/edge/' path")
+		}
+		if !strings.Contains(linuxData.Deb.Download, "/edge/") {
+			t.Error("EDGE DEB should contain '/edge/' path")
+		}
+	})
+
+	t.Run("Docker tags use release version", func(t *testing.T) {
+		result := generateEnterpriseDownloadsJSON(semVerTag, "minio-enterprise", releaseTag, false)
+
+		dockerData := result.Subscriptions["Enterprise"].Docker["AIStor Server"]["amd64"]
+		if dockerData.Podman == nil {
+			t.Fatal("Docker Podman info missing")
+		}
+		if !strings.Contains(dockerData.Podman.Text, releaseTag) {
+			t.Errorf("Docker should use release tag %s, got: %s", releaseTag, dockerData.Podman.Text)
+		}
+		if strings.Contains(dockerData.Podman.Text, ":latest") {
+			t.Error("Docker should NOT use :latest tag")
+		}
+	})
+
+	t.Run("MC Enterprise", func(t *testing.T) {
+		result := generateEnterpriseDownloadsJSON(semVerTag, "mc-enterprise", releaseTag, false)
+
+		linuxData := result.Subscriptions["Enterprise"].Linux["AIStor Client"]["amd64"]
+		if linuxData.Bin == nil {
+			t.Error("Binary download info missing for mc-enterprise")
+		}
+
+		// Verify mc paths
+		if !strings.Contains(linuxData.Bin.Download, "/aistor/mc/") {
+			t.Error("MC should use /aistor/mc/ path")
+		}
+	})
+}
+
+// TestGenerateDownloadsJSON tests community JSON generation
+func TestGenerateDownloadsJSON(t *testing.T) {
+	semVerTag := "20250312000000.0.0"
+
+	t.Run("MinIO Community", func(t *testing.T) {
+		result := generateDownloadsJSON(semVerTag, "minio")
+
+		// Verify Linux has all architectures
+		if _, ok := result.Linux["MinIO Server"]["amd64"]; !ok {
+			t.Error("amd64 architecture missing")
+		}
+		if _, ok := result.Linux["MinIO Server"]["arm64"]; !ok {
+			t.Error("arm64 architecture missing")
+		}
+		if _, ok := result.Linux["MinIO Server"]["ppc64le"]; !ok {
+			t.Error("ppc64le architecture missing")
+		}
+
+		// Verify RPM architecture mapping
+		rpmData := result.Linux["MinIO Server"]["amd64"].RPM
+		if !strings.Contains(rpmData.Download, "x86_64.rpm") {
+			t.Error("RPM should use x86_64 architecture for amd64")
+		}
+
+		// Verify DEB architecture mapping
+		debData := result.Linux["MinIO Server"]["amd64"].Deb
+		if !strings.Contains(debData.Download, "_amd64.deb") {
+			t.Error("DEB should use amd64 architecture")
+		}
+	})
+
+	t.Run("MC Community", func(t *testing.T) {
+		result := generateDownloadsJSON(semVerTag, "mc")
+
+		// Verify package name is mcli not mc
+		rpmData := result.Linux["MinIO Client"]["amd64"].RPM
+		if !strings.Contains(rpmData.Download, "mcli-") {
+			t.Error("MC packages should be named 'mcli'")
+		}
+	})
+}
+
+// TestGenerateSidekickDownloadsJSON tests sidekick JSON generation
+func TestGenerateSidekickDownloadsJSON(t *testing.T) {
+	semVerTag := "20250312000000.0.0"
+	releaseTag := "RELEASE.2025-03-12T00-00-00Z"
+
+	result := generateSidekickDownloadsJSON(semVerTag, releaseTag)
+
+	// Verify only Linux support
+	if result.MacOS != nil {
+		t.Error("Sidekick should not have MacOS support")
+	}
+	if result.Windows != nil {
+		t.Error("Sidekick should not have Windows support")
+	}
+
+	// Verify only amd64 and arm64
+	if _, ok := result.Linux["Sidekick"]["amd64"]; !ok {
+		t.Error("amd64 architecture missing")
+	}
+	if _, ok := result.Linux["Sidekick"]["arm64"]; !ok {
+		t.Error("arm64 architecture missing")
+	}
+	if _, ok := result.Linux["Sidekick"]["ppc64le"]; ok {
+		t.Error("ppc64le should not be supported for sidekick")
+	}
+
+	// Verify no binary downloads, only packages
+	linuxData := result.Linux["Sidekick"]["amd64"]
+	if linuxData.Bin != nil {
+		t.Error("Sidekick should not have binary downloads")
+	}
+	if linuxData.RPM == nil {
+		t.Error("Sidekick should have RPM packages")
+	}
+	if linuxData.Deb == nil {
+		t.Error("Sidekick should have DEB packages")
+	}
+}
+
+// TestGenerateWarpDownloadsJSON tests warp JSON generation
+func TestGenerateWarpDownloadsJSON(t *testing.T) {
+	version := "0.4.3"      // Without 'v' prefix
+	releaseTag := "v0.4.3" // With 'v' prefix
+
+	result := generateWarpDownloadsJSON(version, releaseTag)
+
+	// Verify cross-platform support
+	if result.Linux == nil {
+		t.Error("Warp should support Linux")
+	}
+	if result.MacOS == nil {
+		t.Error("Warp should support MacOS")
+	}
+	if result.Windows == nil {
+		t.Error("Warp should support Windows")
+	}
+
+	// Verify Linux architectures (amd64, arm64 only)
+	if _, ok := result.Linux["Warp"]["amd64"]; !ok {
+		t.Error("amd64 architecture missing for Linux")
+	}
+	if _, ok := result.Linux["Warp"]["arm64"]; !ok {
+		t.Error("arm64 architecture missing for Linux")
+	}
+	if _, ok := result.Linux["Warp"]["ppc64le"]; ok {
+		t.Error("ppc64le should not be supported for warp")
+	}
+
+	// Verify MacOS only arm64
+	if _, ok := result.MacOS["Warp"]["arm64"]; !ok {
+		t.Error("arm64 architecture missing for MacOS")
+	}
+	if _, ok := result.MacOS["Warp"]["amd64"]; ok {
+		t.Error("amd64 should not be supported for MacOS warp")
+	}
+
+	// Verify Windows only amd64
+	if _, ok := result.Windows["Warp"]["amd64"]; !ok {
+		t.Error("amd64 architecture missing for Windows")
+	}
+
+	// Verify version format in URLs (without 'v' prefix)
+	linuxData := result.Linux["Warp"]["amd64"]
+	if strings.Contains(linuxData.RPM.Download, "v0.4.3") {
+		t.Error("RPM URL should not contain 'v' prefix")
+	}
+	if !strings.Contains(linuxData.RPM.Download, "0.4.3") {
+		t.Error("RPM URL should contain version without 'v' prefix")
+	}
+}
+
+// TestReleaseDirName tests release directory name logic
+func TestReleaseDirName(t *testing.T) {
+	tests := []struct {
+		name     string
+		appName  string
+		expected string
+	}{
+		{
+			name:     "minio-enterprise",
+			appName:  "minio-enterprise",
+			expected: "minio-release",
+		},
+		{
+			name:     "mc-enterprise",
+			appName:  "mc-enterprise",
+			expected: "mc-release",
+		},
+		{
+			name:     "minio",
+			appName:  "minio",
+			expected: "minio-release",
+		},
+		{
+			name:     "sidekick",
+			appName:  "sidekick",
+			expected: "sidekick-release",
+		},
+		{
+			name:     "warp",
+			appName:  "warp",
+			expected: "warp-release",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore global state
+			oldAppName := appName
+			oldReleaseDir := releaseDir
+			defer func() {
+				appName = oldAppName
+				releaseDir = oldReleaseDir
+			}()
+
+			// Set test values
+			*appName = tt.appName
+			*releaseDir = ""
+
+			result := releaseDirName()
+			if result != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestArchitectureMappings tests RPM and DEB architecture mappings
+func TestArchitectureMappings(t *testing.T) {
+	t.Run("RPM arch mapping", func(t *testing.T) {
+		if rpmArchMap["amd64"] != "x86_64" {
+			t.Error("amd64 should map to x86_64 for RPM")
+		}
+		if rpmArchMap["arm64"] != "aarch64" {
+			t.Error("arm64 should map to aarch64 for RPM")
+		}
+	})
+
+	t.Run("DEB arch mapping", func(t *testing.T) {
+		if debArchMap["amd64"] != "amd64" {
+			t.Error("amd64 should map to amd64 for DEB")
+		}
+		if debArchMap["arm64"] != "arm64" {
+			t.Error("arm64 should map to arm64 for DEB")
+		}
+	})
+}
+
+// TestURLPathStructure validates URL structure for different release types
+func TestURLPathStructure(t *testing.T) {
+	semVerTag := "20250312000000.0.0"
+	releaseTag := "RELEASE.2025-03-12T00-00-00Z"
+
+	t.Run("Community MinIO uses /server/minio/release/", func(t *testing.T) {
+		result := generateDownloadsJSON(semVerTag, "minio")
+		binURL := result.Linux["MinIO Server"]["amd64"].Bin.Download
+		if !strings.HasPrefix(binURL, "https://dl.min.io/server/minio/release/") {
+			t.Errorf("Unexpected URL structure: %s", binURL)
+		}
+	})
+
+	t.Run("Enterprise MinIO uses /aistor/minio/release/", func(t *testing.T) {
+		result := generateEnterpriseDownloadsJSON(semVerTag, "minio-enterprise", releaseTag, false)
+		binURL := result.Subscriptions["Enterprise"].Linux["AIStor Server"]["amd64"].Bin.Download
+		if !strings.HasPrefix(binURL, "https://dl.min.io/aistor/minio/release/") {
+			t.Errorf("Unexpected URL structure: %s", binURL)
+		}
+	})
+
+	t.Run("Enterprise EDGE uses /aistor/minio/edge/", func(t *testing.T) {
+		result := generateEnterpriseDownloadsJSON(semVerTag, "minio-enterprise", releaseTag, true)
+		binURL := result.Subscriptions["Enterprise"].Linux["AIStor Server"]["amd64"].Bin.Download
+		if !strings.HasPrefix(binURL, "https://dl.min.io/aistor/minio/edge/") {
+			t.Errorf("Unexpected EDGE URL structure: %s", binURL)
+		}
+	})
+
+	t.Run("Sidekick uses /aistor/sidekick/release/", func(t *testing.T) {
+		result := generateSidekickDownloadsJSON(semVerTag, releaseTag)
+		rpmURL := result.Linux["Sidekick"]["amd64"].RPM.Download
+		if !strings.HasPrefix(rpmURL, "https://dl.min.io/aistor/sidekick/release/") {
+			t.Errorf("Unexpected URL structure: %s", rpmURL)
+		}
+	})
+
+	t.Run("Warp uses /aistor/warp/release/", func(t *testing.T) {
+		result := generateWarpDownloadsJSON("0.4.3", "v0.4.3")
+		binURL := result.Linux["Warp"]["amd64"].Bin.Download
+		if !strings.HasPrefix(binURL, "https://dl.min.io/aistor/warp/release/") {
+			t.Errorf("Unexpected URL structure: %s", binURL)
+		}
+	})
+}


### PR DESCRIPTION
This commit adds comprehensive EDGE release support and Kubernetes/Docker deployment documentation for sidekick and warp applications.

Features:
- Add --edge flag to generate EDGE release metadata with /edge/ URLs
- Generate separate downloads-{appName}-edge.json files for EDGE releases
- Add Kubernetes and Docker deployment instructions for sidekick and warp
- Use actual release tags in container images instead of :latest
- Skip package building for warp (uses goreleaser)

Changes:
- Add --edge/-e command-line flag for EDGE release generation
- Update generateEnterpriseDownloadsJSON() to support dynamic path segments
- Add generateSidekickDownloadsJSON() with Kubernetes/Docker support
- Add generateWarpDownloadsJSON() with Kubernetes/Docker support
- Fix all Docker/Podman instructions to use release tags
- Add comprehensive unit test suite in main_test.go
- Update README.md with natural language formatting
- Add CLAUDE.md for future development guidance

All container images use quay.io/minio/aistor/{app}:{release-tag} format. Tests: All 8 test suites passing.