### PR TITLE
Update product names and add sidekick systemd service support

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -208,18 +208,18 @@ func TestGenerateSidekickDownloadsJSON(t *testing.T) {
 	}
 
 	// Verify only amd64 and arm64
-	if _, ok := result.Linux["Sidekick"]["amd64"]; !ok {
+	if _, ok := result.Linux["MinIO Sidekick"]["amd64"]; !ok {
 		t.Error("amd64 architecture missing")
 	}
-	if _, ok := result.Linux["Sidekick"]["arm64"]; !ok {
+	if _, ok := result.Linux["MinIO Sidekick"]["arm64"]; !ok {
 		t.Error("arm64 architecture missing")
 	}
-	if _, ok := result.Linux["Sidekick"]["ppc64le"]; ok {
+	if _, ok := result.Linux["MinIO Sidekick"]["ppc64le"]; ok {
 		t.Error("ppc64le should not be supported for sidekick")
 	}
 
 	// Verify no binary downloads, only packages
-	linuxData := result.Linux["Sidekick"]["amd64"]
+	linuxData := result.Linux["MinIO Sidekick"]["amd64"]
 	if linuxData.Bin != nil {
 		t.Error("Sidekick should not have binary downloads")
 	}
@@ -250,31 +250,31 @@ func TestGenerateWarpDownloadsJSON(t *testing.T) {
 	}
 
 	// Verify Linux architectures (amd64, arm64 only)
-	if _, ok := result.Linux["Warp"]["amd64"]; !ok {
+	if _, ok := result.Linux["MinIO Warp"]["amd64"]; !ok {
 		t.Error("amd64 architecture missing for Linux")
 	}
-	if _, ok := result.Linux["Warp"]["arm64"]; !ok {
+	if _, ok := result.Linux["MinIO Warp"]["arm64"]; !ok {
 		t.Error("arm64 architecture missing for Linux")
 	}
-	if _, ok := result.Linux["Warp"]["ppc64le"]; ok {
+	if _, ok := result.Linux["MinIO Warp"]["ppc64le"]; ok {
 		t.Error("ppc64le should not be supported for warp")
 	}
 
 	// Verify MacOS only arm64
-	if _, ok := result.MacOS["Warp"]["arm64"]; !ok {
+	if _, ok := result.MacOS["MinIO Warp"]["arm64"]; !ok {
 		t.Error("arm64 architecture missing for MacOS")
 	}
-	if _, ok := result.MacOS["Warp"]["amd64"]; ok {
+	if _, ok := result.MacOS["MinIO Warp"]["amd64"]; ok {
 		t.Error("amd64 should not be supported for MacOS warp")
 	}
 
 	// Verify Windows only amd64
-	if _, ok := result.Windows["Warp"]["amd64"]; !ok {
+	if _, ok := result.Windows["MinIO Warp"]["amd64"]; !ok {
 		t.Error("amd64 architecture missing for Windows")
 	}
 
 	// Verify version format in URLs (without 'v' prefix)
-	linuxData := result.Linux["Warp"]["amd64"]
+	linuxData := result.Linux["MinIO Warp"]["amd64"]
 	if strings.Contains(linuxData.RPM.Download, "v0.4.3") {
 		t.Error("RPM URL should not contain 'v' prefix")
 	}
@@ -391,7 +391,7 @@ func TestURLPathStructure(t *testing.T) {
 
 	t.Run("Sidekick uses /aistor/sidekick/release/", func(t *testing.T) {
 		result := generateSidekickDownloadsJSON(semVerTag, releaseTag)
-		rpmURL := result.Linux["Sidekick"]["amd64"].RPM.Download
+		rpmURL := result.Linux["MinIO Sidekick"]["amd64"].RPM.Download
 		if !strings.HasPrefix(rpmURL, "https://dl.min.io/aistor/sidekick/release/") {
 			t.Errorf("Unexpected URL structure: %s", rpmURL)
 		}
@@ -399,7 +399,7 @@ func TestURLPathStructure(t *testing.T) {
 
 	t.Run("Warp uses /aistor/warp/release/", func(t *testing.T) {
 		result := generateWarpDownloadsJSON("0.4.3", "v0.4.3")
-		binURL := result.Linux["Warp"]["amd64"].Bin.Download
+		binURL := result.Linux["MinIO Warp"]["amd64"].Bin.Download
 		if !strings.HasPrefix(binURL, "https://dl.min.io/aistor/warp/release/") {
 			t.Errorf("Unexpected URL structure: %s", binURL)
 		}

--- a/sidekick.service
+++ b/sidekick.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Sidekick
+Documentation=https://github.com/minio/sidekick/blob/master/README.md
+Wants=network-online.target
+After=network-online.target
+AssertFileIsExecutable=/usr/bin/sidekick
+
+[Service]
+User=nobody
+Group=nogroup
+
+EnvironmentFile=/etc/default/sidekick
+
+ExecStart=/usr/bin/sidekick $SIDEKICK_OPTIONS $SIDEKICK_SITES
+
+# Let systemd restart this service always
+Restart=always
+
+# Specifies the maximum file descriptor number that can be opened by this process
+LimitNOFILE=65536
+
+# Disable timeout logic and wait until process is stopped
+TimeoutStopSec=infinity
+SendSIGKILL=no
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Changes:
- Update product names: MinIO KMS, MinIO Sidekick, MinIO Warp
- Remove deprecated Firewall/Loadbalancer references
- Separate minio-enterprise and mc-enterprise JSON generation
- Add sidekick.service systemd file for RPM/DEB packages
- Fix enterprise JSON to only include relevant products per appName

Product naming:
- "AIStor Key Manager" → "MinIO KMS"
- "AIStor Sidekick" → "MinIO Sidekick"
- "AIStor Warp" → "MinIO Warp"
- "AIStor Loadbalancer/Firewall" → removed (now part of main MinIO AIStor)

Sidekick packaging:
- Add sidekick.service file from minio/sidekick repository
- Template updated to include sidekick.service in RPM/DEB packages
- Service file installed to /lib/systemd/system/sidekick.service