### PR TITLE
Remove comments and update the instructions to align with the rest

### DIFF
--- a/main.go
+++ b/main.go
@@ -565,23 +565,13 @@ podman run --name my-sidekick -it --rm quay.io/minio/aistor/sidekick:%s --versio
 			RPM: &dlInfo{
 				Download: fmt.Sprintf("https://dl.min.io/aistor/sidekick/release/linux-%s/sidekick-%s-1.%s.rpm", arch, semVerTag, rpmArchMap[arch]),
 				Checksum: fmt.Sprintf("https://dl.min.io/aistor/sidekick/release/linux-%s/sidekick-%s-1.%s.rpm.sha256sum", arch, semVerTag, rpmArchMap[arch]),
-				Text: fmt.Sprintf(`# Download the RPM package
-wget https://dl.min.io/aistor/sidekick/release/linux-%s/sidekick-%s-1.%s.rpm
-
-# Install with yum/dnf
-sudo yum install sidekick-%s-1.%s.rpm
-# or
+				Text: fmt.Sprintf(`wget https://dl.min.io/aistor/sidekick/release/linux-%s/sidekick-%s-1.%s.rpm
 sudo dnf install sidekick-%s-1.%s.rpm`, arch, semVerTag, rpmArchMap[arch], semVerTag, rpmArchMap[arch], semVerTag, rpmArchMap[arch]),
 			},
 			Deb: &dlInfo{
 				Download: fmt.Sprintf("https://dl.min.io/aistor/sidekick/release/linux-%s/sidekick_%s_%s.deb", arch, semVerTag, debArchMap[arch]),
 				Checksum: fmt.Sprintf("https://dl.min.io/aistor/sidekick/release/linux-%s/sidekick_%s_%s.deb.sha256sum", arch, semVerTag, debArchMap[arch]),
-				Text: fmt.Sprintf(`# Download the DEB package
-wget https://dl.min.io/aistor/sidekick/release/linux-%s/sidekick_%s_%s.deb
-
-# Install with apt
-sudo apt install ./sidekick_%s_%s.deb
-# or
+				Text: fmt.Sprintf(`wget https://dl.min.io/aistor/sidekick/release/linux-%s/sidekick_%s_%s.deb
 sudo dpkg -i sidekick_%s_%s.deb`, arch, semVerTag, debArchMap[arch], semVerTag, debArchMap[arch], semVerTag, debArchMap[arch]),
 			},
 		}


### PR DESCRIPTION
As requested by AB, I’ve removed the comments and extra commands from the Sidekick instructions to keep them consistent with the rest.