### PR TITLE
Update AIStor Client Podman command

### DIFF
--- a/main.go
+++ b/main.go
@@ -289,6 +289,7 @@ mcli --version`, pathSegment, arch, semVerTag, debArchMap[arch], semVerTag, debA
 					Podman: &dlInfo{
 						Text: fmt.Sprintf(`podman pull quay.io/minio/aistor/mc:%s
 podman run --name my-mc --hostname my-mc -it --entrypoint /bin/bash --rm minio/mc
+quay.io/minio/aistor/mc
 mc --version`, releaseTag),
 					},
 				}


### PR DESCRIPTION
Updated the AIStor Client Podman instructions as below:

**CURRENT**:
```
podman pull quay.io/minio/aistor/mc:RELEASE.2025-12-19T20-11-44Z
podman run --name my-mc --hostname my-mc -it --entrypoint /bin/bash --rm minio/mc
mc --version
```

**UPDATED**
```
podman pull quay.io/minio/aistor/mc:RELEASE.2025-12-19T20-11-44Z
podman run --name my-mc --hostname my-mc -it --entrypoint /bin/bash --rm 
quay.io/minio/aistor/mc
mc --version 
```